### PR TITLE
Remove unused dependency on obsolete egg

### DIFF
--- a/srfi/testing.scm
+++ b/srfi/testing.scm
@@ -25,8 +25,6 @@
 ;; SOFTWARE.
 
 (cond-expand
- (chicken
-  (require-extension syntax-case))
  (guile-2
   (use-modules (srfi srfi-9)
                ;; In 2.0.9, srfi-34 and srfi-35 are not well integrated


### PR DESCRIPTION
There used to be a syntax-case egg in CHICKEN 3. We're at CHICKEN 5 now and I don't see any chance of the syntax-case egg returning. Besides, while it's imported, it's never used. So there should be no loss with omitting that particular import, it only impedes installation via snow-chibi.